### PR TITLE
use new Kubernetes Tooling sidecar eclipse/che#15655

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
-FROM quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.0
+FROM quay.io/eclipse/che-sidecar-kubernetes-tooling:1.0.4-a46d022
 
 ENV KAMEL_VERSION 1.0.0-M4
 


### PR DESCRIPTION
it ensures ot use the corresponding sidecar image version with the
upgraded VS Code Kubernetes extension in Camel K stack

Signed-off-by: Aurélien Pupier <apupier@redhat.com>